### PR TITLE
Change the script to use the parent's pom instead

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,7 @@ run_tests() {
 }
 
 build_packages() {
-    exec mvn package -f "$MYLYN_SRC/org.tuleap.mylyn.task.repository"
+    exec mvn package -f "$MYLYN_SRC/org.tuleap.mylyn.task.parent/pom.xml"
 }
 
 export JAVA_HOME='/usr/lib/jvm/java-8-openjdk-amd64/jre'


### PR DESCRIPTION
Using the package goal, tests won't run and the update site will be in
the repository plugin.

Signed-off-by: Patrick-Jeffrey Pollo Guilbert patrick.pollo.guilbert@ericsson.com
